### PR TITLE
Add FastAPI main application

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,26 @@
+import uvicorn
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from .auth import router as auth_router
+from .ws_bridge import router as ws_router
+
+app = FastAPI(title="Realtime Adapter Service (Python)")
+
+# CORS tuỳ nhu cầu
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+app.include_router(auth_router)
+app.include_router(ws_router)
+
+@app.get("/healthz")
+def healthz():
+    return {"ok": True}
+
+if __name__ == "__main__":
+    uvicorn.run("app.main:app", host="0.0.0.0", port=8080, reload=True)


### PR DESCRIPTION
## Summary
- add FastAPI entrypoint configuring CORS and routers
- expose `/healthz` endpoint for service readiness

## Testing
- `python -m py_compile app/main.py`


------
https://chatgpt.com/codex/tasks/task_b_6898a2b7ace8832a85b8fa0972f174ca