### PR TITLE
Add authentication schema definitions

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,0 +1,24 @@
+from pydantic import BaseModel
+from typing import Optional, Any, Dict
+
+
+class LoginIn(BaseModel):
+    username: str
+    password: str
+
+
+class LoginOut(BaseModel):
+    ok: bool
+    token: str
+    user: Optional[Dict[str, Any]] = None
+
+
+class CheckLoginOut(BaseModel):
+    logged_in: bool
+    user: Optional[Dict[str, Any]] = None
+    token_expires_at: Optional[int] = None  # epoch seconds
+
+
+class ErrorOut(BaseModel):
+    ok: bool = False
+    error: str


### PR DESCRIPTION
## Summary
- define pydantic models for login requests and responses

## Testing
- `python -m py_compile app/schemas.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6898a182d1bc832a9bc508610552099f