### PR TITLE
Initialize python realtime service skeleton

### DIFF
--- a/python-realtime-service/README.md
+++ b/python-realtime-service/README.md
@@ -1,0 +1,11 @@
+# Python Realtime Service
+
+A minimal FastAPI-based realtime service with session storage and a WebSocket
+bridge.
+
+## Getting Started
+
+```bash
+pip install -r requirements.txt
+uvicorn app.main:app --reload
+```

--- a/python-realtime-service/app/__init__.py
+++ b/python-realtime-service/app/__init__.py
@@ -1,0 +1,3 @@
+"""Package for Python realtime service."""
+
+__all__ = []

--- a/python-realtime-service/app/auth.py
+++ b/python-realtime-service/app/auth.py
@@ -1,0 +1,28 @@
+from uuid import uuid4
+
+from fastapi import APIRouter
+
+from . import storage
+from .schemas import (
+    CheckLoginRequest,
+    CheckLoginResponse,
+    LoginRequest,
+    LoginResponse,
+)
+
+router = APIRouter()
+
+
+@router.post("/login", response_model=LoginResponse)
+def login(data: LoginRequest) -> LoginResponse:
+    """Authenticate a user and create a session token."""
+    token = uuid4().hex
+    storage.set_session(token, {"username": data.username})
+    return LoginResponse(token=token)
+
+
+@router.post("/check_login", response_model=CheckLoginResponse)
+def check_login(data: CheckLoginRequest) -> CheckLoginResponse:
+    """Check whether the supplied session token is valid."""
+    valid = storage.get_session(data.token) is not None
+    return CheckLoginResponse(valid=valid)

--- a/python-realtime-service/app/config.py
+++ b/python-realtime-service/app/config.py
@@ -1,0 +1,21 @@
+from functools import lru_cache
+
+from pydantic import BaseSettings
+
+
+class Settings(BaseSettings):
+    """Application settings loaded from environment variables."""
+
+    secret_key: str = "secret"
+    backend_url: str = "ws://localhost:9000/ws"
+
+    class Config:
+        env_file = ".env"
+        env_file_encoding = "utf-8"
+
+
+@lru_cache()
+def get_settings() -> Settings:
+    """Return cached application settings."""
+
+    return Settings()

--- a/python-realtime-service/app/main.py
+++ b/python-realtime-service/app/main.py
@@ -1,0 +1,15 @@
+from fastapi import FastAPI
+
+from .auth import router as auth_router
+from .ws_bridge import router as ws_router
+
+app = FastAPI()
+
+app.include_router(auth_router)
+app.include_router(ws_router)
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run("app.main:app", host="0.0.0.0", port=8000, reload=True)

--- a/python-realtime-service/app/schemas.py
+++ b/python-realtime-service/app/schemas.py
@@ -1,0 +1,18 @@
+from pydantic import BaseModel
+
+
+class LoginRequest(BaseModel):
+    username: str
+    password: str
+
+
+class LoginResponse(BaseModel):
+    token: str
+
+
+class CheckLoginRequest(BaseModel):
+    token: str
+
+
+class CheckLoginResponse(BaseModel):
+    valid: bool

--- a/python-realtime-service/app/storage.py
+++ b/python-realtime-service/app/storage.py
@@ -1,0 +1,32 @@
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+SESSIONS_FILE = Path(__file__).with_name("sessions.json")
+
+
+def load_sessions() -> Dict[str, Any]:
+    """Load all sessions from the JSON storage file."""
+    if SESSIONS_FILE.exists():
+        with SESSIONS_FILE.open("r", encoding="utf-8") as fh:
+            return json.load(fh)
+    return {}
+
+
+def save_sessions(data: Dict[str, Any]) -> None:
+    """Persist sessions to the JSON storage file."""
+    with SESSIONS_FILE.open("w", encoding="utf-8") as fh:
+        json.dump(data, fh)
+
+
+def get_session(token: str) -> Any:
+    """Retrieve a session by token."""
+    sessions = load_sessions()
+    return sessions.get(token)
+
+
+def set_session(token: str, value: Any) -> None:
+    """Store session data by token."""
+    sessions = load_sessions()
+    sessions[token] = value
+    save_sessions(sessions)

--- a/python-realtime-service/app/utils.py
+++ b/python-realtime-service/app/utils.py
@@ -1,0 +1,14 @@
+import time
+from typing import Any, Dict
+
+import jwt
+
+
+def decode_jwt(token: str, secret: str) -> Dict[str, Any]:
+    """Decode a JWT token with the given secret."""
+    return jwt.decode(token, secret, algorithms=["HS256"])
+
+
+def now() -> float:
+    """Return the current Unix timestamp."""
+    return time.time()

--- a/python-realtime-service/app/ws_bridge.py
+++ b/python-realtime-service/app/ws_bridge.py
@@ -1,0 +1,28 @@
+import asyncio
+
+import websockets
+from fastapi import APIRouter, WebSocket
+
+from .config import get_settings
+
+router = APIRouter()
+
+
+@router.websocket("/socket")
+async def websocket_proxy(ws: WebSocket) -> None:
+    """Proxy messages between the client WebSocket and backend server."""
+    await ws.accept()
+    settings = get_settings()
+
+    async with websockets.connect(settings.backend_url) as backend:
+        async def client_to_backend() -> None:
+            while True:
+                data = await ws.receive_text()
+                await backend.send(data)
+
+        async def backend_to_client() -> None:
+            while True:
+                data = await backend.recv()
+                await ws.send_text(data)
+
+        await asyncio.gather(client_to_backend(), backend_to_client())

--- a/python-realtime-service/requirements.txt
+++ b/python-realtime-service/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+pydantic
+websockets
+pyjwt


### PR DESCRIPTION
## Summary
- scaffold FastAPI realtime service with authentication and websocket bridge
- add JSON-based session storage and utility helpers
- document project setup and dependencies

## Testing
- `python -m py_compile $(find python-realtime-service -name "*.py" -print)`

------
https://chatgpt.com/codex/tasks/task_b_6898a12ffa28832abee1ed71950e29e6