### PR TITLE
Add settings configuration

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,25 @@
+import os
+from pydantic import BaseSettings, Field
+
+class Settings(BaseSettings):
+    # URL backend thật mà các file JS đang nói chuyện:
+    # ví dụ: AUTH_BASE_URL=https://api.example.com
+    AUTH_BASE_URL: str = Field(..., description="Base URL cho auth backend (có /login)")
+    REALTIME_WS_URL: str = Field(..., description="WS URL của hệ thống realtime, ví dụ wss://rt.example.com/ws")
+
+    # Tên header mang token khi đi backend (nếu cần)
+    UPSTREAM_AUTH_HEADER: str = Field("Authorization", description="Header auth gửi lên backend realtime")
+
+    # Secret cục bộ để ký/verify session (nếu bạn muốn tự quản)
+    LOCAL_SESSION_SECRET: str = Field("dev-local-secret", description="Local secret cho HMAC/JWT nhẹ")
+
+    # File lưu session (simple JSON). Có thể thay bằng Redis/DB sau
+    SESSION_STORE_PATH: str = Field("./sessions.json")
+
+    # Thời hạn session cục bộ (nếu backend không cung cấp refresh logic)
+    SESSION_TTL_SECONDS: int = Field(86400)
+
+    class Config:
+        env_file = ".env"
+
+settings = Settings()


### PR DESCRIPTION
## Summary
- add a Pydantic `Settings` class for auth and session configuration

## Testing
- `pytest`
- `pip install pydantic` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_b_6898a1711500832a9849c0a94a5f94fb